### PR TITLE
Add project deployer address

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,9 +1,5 @@
 {
   "network": "mainnet",
-  "graft": {
-    "base": "QmTqzub5eATCZRuqDT2jLXPyuzSpZmMbwDnjsQK8NdAkCz",
-    "startBlock": 15930500
-  },
   "v1": {
     "address_projects": "0x9b5a4053FfBB11cA9cd858AAEE43cc95ab435418",
     "startBlock_projects": 12833329,

--- a/schema.graphql
+++ b/schema.graphql
@@ -54,9 +54,9 @@ type Project @entity {
 
   # Only v2 + v3
   metadataDomain: BigInt
+  deployer: Bytes
 
   owner: Bytes!
-  deployer: Bytes!
   createdAt: Int!
   totalPaid: BigInt!
   totalRedeemed: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -56,6 +56,7 @@ type Project @entity {
   metadataDomain: BigInt
 
   owner: Bytes!
+  creator: Bytes!
   createdAt: Int!
   totalPaid: BigInt!
   totalRedeemed: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -56,7 +56,7 @@ type Project @entity {
   metadataDomain: BigInt
 
   owner: Bytes!
-  creator: Bytes!
+  deployer: Bytes!
   createdAt: Int!
   totalPaid: BigInt!
   totalRedeemed: BigInt!

--- a/src/mappings/v1.x/projects.ts
+++ b/src/mappings/v1.x/projects.ts
@@ -30,6 +30,7 @@ export function handleProjectCreate(event: Create): void {
   if (!project) return;
   project.projectId = event.params.projectId.toI32();
   project.pv = pv;
+  project.deployer = event.transaction.from;
   project.trendingScore = BigInt.fromString("0");
   project.trendingVolume = BigInt.fromString("0");
   project.trendingPaymentsCount = BigInt.fromString("0").toI32();

--- a/src/mappings/v1.x/projects.ts
+++ b/src/mappings/v1.x/projects.ts
@@ -30,7 +30,6 @@ export function handleProjectCreate(event: Create): void {
   if (!project) return;
   project.projectId = event.params.projectId.toI32();
   project.pv = pv;
-  project.deployer = event.transaction.from;
   project.trendingScore = BigInt.fromString("0");
   project.trendingVolume = BigInt.fromString("0");
   project.trendingPaymentsCount = BigInt.fromString("0").toI32();

--- a/src/mappings/v2/jbController.ts
+++ b/src/mappings/v2/jbController.ts
@@ -9,6 +9,7 @@ import {
 import {
   DistributeReservedTokens,
   DistributeToReservedTokenSplit,
+  LaunchProject,
   Migrate,
   MintTokens,
 } from "../../../generated/V2JBController/JBController";
@@ -138,5 +139,23 @@ export function handleMigrate(event: Migrate): void {
   const project = Project.load(projectId);
   if (!project) return;
   project.pv = pv;
+  project.save();
+}
+
+export function handleLaunchProject(event: LaunchProject): void {
+  const projectId = idForProject(event.params.projectId, pv);
+
+  const project = Project.load(projectId);
+
+  if (!project) {
+    log.error("[v2 handleLaunchProject] project not found for id: {}", [
+      projectId,
+    ]);
+    return;
+  }
+
+  // If the controller emits a launchProject event, the project launch tx was called via the JBController, and we want to prefer its `caller` param over any existing value
+  project.deployer = event.params.caller;
+
   project.save();
 }

--- a/src/mappings/v2/jbProjects.ts
+++ b/src/mappings/v2/jbProjects.ts
@@ -39,7 +39,7 @@ export function handleCreate(event: Create): void {
   project.trendingPaymentsCount = BigInt.fromString("0").toI32();
   project.createdWithinTrendingWindow = true;
   project.owner = event.params.owner;
-  project.deployer = event.transaction.from;
+  project.deployer = event.params.caller;
   project.createdAt = event.block.timestamp.toI32();
   project.metadataUri = event.params.metadata.content;
   project.metadataDomain = event.params.metadata.domain;

--- a/src/mappings/v2/jbProjects.ts
+++ b/src/mappings/v2/jbProjects.ts
@@ -39,6 +39,7 @@ export function handleCreate(event: Create): void {
   project.trendingPaymentsCount = BigInt.fromString("0").toI32();
   project.createdWithinTrendingWindow = true;
   project.owner = event.params.owner;
+  project.creator = event.transaction.from;
   project.createdAt = event.block.timestamp.toI32();
   project.metadataUri = event.params.metadata.content;
   project.metadataDomain = event.params.metadata.domain;

--- a/src/mappings/v2/jbProjects.ts
+++ b/src/mappings/v2/jbProjects.ts
@@ -39,7 +39,7 @@ export function handleCreate(event: Create): void {
   project.trendingPaymentsCount = BigInt.fromString("0").toI32();
   project.createdWithinTrendingWindow = true;
   project.owner = event.params.owner;
-  project.creator = event.transaction.from;
+  project.deployer = event.transaction.from;
   project.createdAt = event.block.timestamp.toI32();
   project.metadataUri = event.params.metadata.content;
   project.metadataDomain = event.params.metadata.domain;

--- a/src/mappings/v3/jbController.ts
+++ b/src/mappings/v3/jbController.ts
@@ -134,11 +134,12 @@ export function handleDistributeToReservedTokenSplit(
 
 export function handleLaunchProject(event: LaunchProject): void {
   const projectId = idForProject(event.params.projectId, pv);
-  const creator = event.params.caller;
+  const deployer = event.params.caller;
+  if (deployer != event.transaction.from) {
+    const project = Project.load(projectId)!;
 
-  const project = Project.load(projectId)!;
+    project.deployer = deployer;
 
-  project.creator = creator;
-
-  project.save();
+    project.save();
+  }
 }

--- a/src/mappings/v3/jbController.ts
+++ b/src/mappings/v3/jbController.ts
@@ -4,11 +4,13 @@ import {
   DistributeReservedTokensEvent,
   DistributeToReservedTokenSplitEvent,
   MintTokensEvent,
+  Project,
 } from "../../../generated/schema";
 import {
   DistributeReservedTokens,
   DistributeToReservedTokenSplit,
   MintTokens,
+  LaunchProject,
 } from "../../../generated/V3JBController/JBController";
 import { ProjectEventKey, Version } from "../../types";
 import { saveNewProjectEvent } from "../../utils/entities/projectEvent";
@@ -128,4 +130,15 @@ export function handleDistributeToReservedTokenSplit(
     pv,
     ProjectEventKey.distributeToReservedTokenSplitEvent
   );
+}
+
+export function handleLaunchProject(event: LaunchProject): void {
+  const projectId = idForProject(event.params.projectId, pv);
+  const creator = event.params.caller;
+
+  const project = Project.load(projectId)!;
+
+  project.creator = creator;
+
+  project.save();
 }

--- a/src/mappings/v3/jbETHERC20ProjectPayerDeployer.ts
+++ b/src/mappings/v3/jbETHERC20ProjectPayerDeployer.ts
@@ -9,7 +9,7 @@ import { saveNewProjectEvent } from "../../utils/entities/projectEvent";
 import { toHexLowercase } from "../../utils/format";
 import { idForProject } from "../../utils/ids";
 
-const pv: Version = "3";
+const pv: Version = "2";
 
 export function handleDeployProjectPayer(event: DeployProjectPayer): void {
   JBETHERC20ProjectPayer.create(event.params.projectPayer);

--- a/v2.template.yaml
+++ b/v2.template.yaml
@@ -44,6 +44,8 @@
         - name: JBController
           file: ./abis/v2/JBController.json
       eventHandlers:
+        - event: LaunchProject(uint256,uint256,string,address)
+          handler: handleLaunchProject
         - event: MintTokens(indexed address,indexed uint256,uint256,uint256,string,uint256,address)
           handler: handleMintTokens
         - event: DistributeReservedTokens(indexed uint256,indexed uint256,indexed uint256,address,uint256,uint256,string,address)

--- a/v3.template.yaml
+++ b/v3.template.yaml
@@ -40,10 +40,13 @@
         - DistributeReservedTokensEvent
         - DistributeToReservedTokenSplitEvent
         - MintTokensEvent
+        - Project
       abis:
         - name: JBController
           file: ./abis/v3/JBController.json
       eventHandlers:
+        - event: LaunchProject(uint256,uint256,string,address)
+          handler: handleLaunchProject
         - event: MintTokens(indexed address,indexed uint256,uint256,uint256,string,uint256,address)
           handler: handleMintTokens
         - event: DistributeReservedTokens(indexed uint256,indexed uint256,indexed uint256,address,uint256,uint256,string,address)


### PR DESCRIPTION
As per discussion in [JB discord on blunt-finance channel](https://discord.com/channels/775859454780244028/1006697136945106984/1042938705884753974), this PR introduces the `deployer` property in the `Project` entity, which can be used to filter projects deployed by a specific address from the controller.

This can be useful to:
- Other projects like Blunt Finance to easily get the data they need from the JB subgraph
- Identify projects deployed with known addresses on JB UI, to appropriately handle them if needed 

---

- Added deployer in `Project` entity
- Added LaunchProject handler in `v3/jbController`

---

### Notes

Am I loading from projectId correctly in `handleLaunchProject`? `pv` is 3 there, while on `handleCreate` is 2. I suspect the project won't be loaded correctly if pv don't match