### PR TITLE
Add USD amounts

### DIFF
--- a/abis/v1/Prices.json
+++ b/abis/v1/Prices.json
@@ -1,0 +1,161 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "currency",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract AggregatorV3Interface",
+        "name": "feed",
+        "type": "address"
+      }
+    ],
+    "name": "AddFeed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract AggregatorV3Interface",
+        "name": "_feed",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_currency",
+        "type": "uint256"
+      }
+    ],
+    "name": "addFeed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "feedDecimalAdjuster",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "feedFor",
+    "outputs": [
+      {
+        "internalType": "contract AggregatorV3Interface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_currency",
+        "type": "uint256"
+      }
+    ],
+    "name": "getETHPriceFor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "targetDecimals",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/v2/JBPrices.json
+++ b/abis/v2/JBPrices.json
@@ -1,0 +1,192 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "prod1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "denominator",
+        "type": "uint256"
+      }
+    ],
+    "name": "PRBMath__MulDivOverflow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_FEED_ALREADY_EXISTS",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_FEED_NOT_FOUND",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "currency",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "base",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IJBPriceFeed",
+        "name": "feed",
+        "type": "address"
+      }
+    ],
+    "name": "AddFeed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_currency",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_base",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IJBPriceFeed",
+        "name": "_feed",
+        "type": "address"
+      }
+    ],
+    "name": "addFeedFor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "feedFor",
+    "outputs": [
+      {
+        "internalType": "contract IJBPriceFeed",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_currency",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_base",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_decimals",
+        "type": "uint256"
+      }
+    ],
+    "name": "priceFor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/v3/JBPrices.json
+++ b/abis/v3/JBPrices.json
@@ -1,0 +1,192 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "prod1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "denominator",
+        "type": "uint256"
+      }
+    ],
+    "name": "PRBMath__MulDivOverflow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_FEED_ALREADY_EXISTS",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_FEED_NOT_FOUND",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "currency",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "base",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IJBPriceFeed",
+        "name": "feed",
+        "type": "address"
+      }
+    ],
+    "name": "AddFeed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_currency",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_base",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IJBPriceFeed",
+        "name": "_feed",
+        "type": "address"
+      }
+    ],
+    "name": "addFeedFor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "feedFor",
+    "outputs": [
+      {
+        "internalType": "contract IJBPriceFeed",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_currency",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_base",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_decimals",
+        "type": "uint256"
+      }
+    ],
+    "name": "priceFor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,9 +1,5 @@
 {
   "network": "mainnet",
-  "graft": {
-    "base": "QmZxvgyn4MqXcMWwC3u1E9E3sP3QbjruQR13QuNqTfjKVF",
-    "startBlock": 15763000
-  },
   "v1": {
     "address_projects": "0x9b5a4053FfBB11cA9cd858AAEE43cc95ab435418",
     "startBlock_projects": 12833329,

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,5 +1,9 @@
 {
   "network": "mainnet",
+  "graft": {
+    "base": "QmZxvgyn4MqXcMWwC3u1E9E3sP3QbjruQR13QuNqTfjKVF",
+    "startBlock": 15763000
+  },
   "v1": {
     "address_projects": "0x9b5a4053FfBB11cA9cd858AAEE43cc95ab435418",
     "startBlock_projects": 12833329,
@@ -12,7 +16,9 @@
     "address_ticketBooth": "0xee2eBCcB7CDb34a8A822b589F9E8427C24351bfc",
     "startBlock_ticketBooth": 12833339,
     "address_fundingCycles": "0xf507B2A1dD7439201eb07F11E1d62AfB29216e2E",
-    "startBlock_fundingCycles": 12833338
+    "startBlock_fundingCycles": 12833338,
+    "address_prices": "0xa9537Cc42555564206D4E57c0eb6943d56E83A30",
+    "startBlock_prices": 12833326
   },
   "v2": {
     "address_jbProjects": "0xD8B4359143eda5B2d763E127Ed27c77addBc47d3",
@@ -26,7 +32,9 @@
     "address_jbETHERC20ProjectPayerDeployer": "0x9E84bEcA3E4d3cfE5C3b5E1b534363E8D7468ABc",
     "startBlock_jbETHERC20ProjectPayerDeployer": 14730683,
     "address_jbFundingCycleStore": "0x6B8e01DAA8A61b544F96d2738893E05D04BF1D12",
-    "startBlock_jbFundingCycleStore": 14868844
+    "startBlock_jbFundingCycleStore": 14868844,
+    "address_jbPrices": "0xCDE93bdA2a706Fc652F7e75241bA949aCB9f4Fe5",
+    "startBlock_jbPrices": 14730691
   },
   "v3": {
     "address_jbController": "0xFFdD70C318915879d5192e8a0dcbFcB0285b3C98",
@@ -42,7 +50,9 @@
     "address_jbTiered721DelegateDeployer": "0x748575f8aa3da88d478c331dca321282480e6038",
     "startBlock_jbTiered721DelegateDeployer": 15890760,
     "address_jbTiered721DelegateStore": "0xffb2cd8519439a7ddcf2c933caedd938053067d2",
-    "startBlock_jbTiered721DelegateStore": 15890768
+    "startBlock_jbTiered721DelegateStore": 15890768,
+    "address_jbPrices": "0xCDE93bdA2a706Fc652F7e75241bA949aCB9f4Fe5",
+    "startBlock_jbPrices": 14730691
   },
   "shared": {
     "address_legacy_jbProjectHandles": "0xe3c01e9fd2a1dcc6edf0b1058b5757138ef9ffb6",

--- a/config/template.json
+++ b/config/template.json
@@ -11,7 +11,9 @@
     "address_ticketBooth": "0x0000000000000000000000000000000000000000",
     "startBlock_ticketBooth": 0,
     "address_fundingCycles": "0x0000000000000000000000000000000000000000",
-    "startBlock_fundingCycles": 0
+    "startBlock_fundingCycles": 0,
+    "address_prices": "0x0000000000000000000000000000000000000000",
+    "startBlock_prices": 0
   },
   "v2": {
     "address_jbProjects": "0x0000000000000000000000000000000000000000",
@@ -25,7 +27,9 @@
     "address_jbETHERC20ProjectPayerDeployer": "0x0000000000000000000000000000000000000000",
     "startBlock_jbETHERC20ProjectPayerDeployer": 0,
     "address_jbFundingCycleStore": "0x0000000000000000000000000000000000000000",
-    "startBlock_jbFundingCycleStore": 0
+    "startBlock_jbFundingCycleStore": 0,
+    "address_jbPrices": "0x0000000000000000000000000000000000000000",
+    "startBlock_jbPrices": 0
   },
   "v3": {
     "address_jbController": "0x0000000000000000000000000000000000000000",
@@ -41,7 +45,9 @@
     "address_jbTiered721DelegateDeployer": "0x0000000000000000000000000000000000000000",
     "startBlock_jbTiered721DelegateDeployer": 0,
     "address_jbTiered721DelegateStore": "0x0000000000000000000000000000000000000000",
-    "startBlock_jbTiered721DelegateStore": 0
+    "startBlock_jbTiered721DelegateStore": 0,
+    "address_jbPrices": "0x0000000000000000000000000000000000000000",
+    "startBlock_jbPrices": 0
   },
   "shared": {
     "address_legacy_jbProjectHandles": "0x0000000000000000000000000000000000000000",

--- a/schema.graphql
+++ b/schema.graphql
@@ -8,7 +8,9 @@ type ProtocolLog @entity {
 
   projectsCount: Int!
   volumePaid: BigInt!
+  volumePaidUSD: BigInt!
   volumeRedeemed: BigInt!
+  volumeRedeemedUSD: BigInt!
   paymentsCount: Int!
   redeemCount: Int!
   erc20Count: Int!
@@ -59,12 +61,15 @@ type Project @entity {
   owner: Bytes!
   createdAt: Int!
   totalPaid: BigInt!
+  totalPaidUSD: BigInt!
   totalRedeemed: BigInt!
+  totalRedeemedUSD: BigInt!
   currentBalance: BigInt!
   trendingScore: BigInt!
   trendingVolume: BigInt!
   trendingPaymentsCount: Int!
   createdWithinTrendingWindow: Boolean!
+  nftsMintedCount: Int!
 
   # Derived fields
   participants: [Participant!]! @derivedFrom(field: "project")
@@ -104,6 +109,7 @@ type Participant @entity {
   pv: String!
   wallet: Bytes!
   totalPaid: BigInt!
+  totalPaidUSD: BigInt!
   lastPaidTimestamp: Int!
   balance: BigInt!
   stakedBalance: BigInt!
@@ -157,6 +163,7 @@ type PayEvent @entity {
   caller: Bytes!
   beneficiary: Bytes!
   amount: BigInt!
+  amountUSD: BigInt
   note: String!
   feeFromV2Project: Int # Indicates payment is a fee from project with this ID
 }
@@ -173,6 +180,7 @@ type AddToBalanceEvent @entity {
 
   caller: Bytes!
   amount: BigInt!
+  amountUSD: BigInt
   note: String
 }
 
@@ -205,6 +213,7 @@ type RedeemEvent @entity {
   beneficiary: Bytes!
   amount: BigInt!
   returnAmount: BigInt!
+  returnAmountUSD: BigInt
   caller: Bytes!
 }
 
@@ -230,7 +239,9 @@ type ProtocolV1Log @entity {
   log: ProtocolLog!
   projectsCount: Int!
   volumePaid: BigInt!
+  volumePaidUSD: BigInt!
   volumeRedeemed: BigInt!
+  volumeRedeemedUSD: BigInt!
   paymentsCount: Int!
   redeemCount: Int!
   erc20Count: Int!
@@ -267,6 +278,7 @@ type DistributeToPayoutModEvent @entity {
   modBeneficiary: Bytes!
   modPreferUnstaked: Boolean!
   modCut: BigInt!
+  modCutUSD: BigInt
   caller: Bytes!
   tapEvent: TapEvent!
 }
@@ -282,10 +294,14 @@ type TapEvent @entity {
   fundingCycleId: BigInt!
   beneficiary: Bytes!
   amount: BigInt!
+  amountUSD: BigInt
   currency: BigInt!
   netTransferAmount: BigInt!
+  netTransferAmountUSD: BigInt
   beneficiaryTransferAmount: BigInt!
+  beneficiaryTransferAmountUSD: BigInt
   govFeeAmount: BigInt!
+  govFeeAmountUSD: BigInt
   caller: Bytes!
   distributions: [DistributeToPayoutModEvent!]! @derivedFrom(field: "tapEvent")
 }
@@ -361,7 +377,9 @@ type ProtocolV2Log @entity {
   log: ProtocolLog!
   projectsCount: Int!
   volumePaid: BigInt!
+  volumePaidUSD: BigInt!
   volumeRedeemed: BigInt!
+  volumeRedeemedUSD: BigInt!
   paymentsCount: Int!
   redeemCount: Int!
   erc20Count: Int!
@@ -380,9 +398,13 @@ type DistributePayoutsEvent @entity {
   fundingCycleNumber: Int!
   beneficiary: Bytes!
   amount: BigInt!
+  amountUSD: BigInt
   distributedAmount: BigInt!
+  distributedAmountUSD: BigInt
   fee: BigInt!
+  feeUSD: BigInt
   beneficiaryDistributionAmount: BigInt!
+  beneficiaryDistributionAmountUSD: BigInt
   memo: String!
   caller: Bytes!
   splitDistributions: [DistributeToPayoutSplitEvent!]!
@@ -401,6 +423,7 @@ type DistributeToPayoutSplitEvent @entity {
   domain: BigInt!
   group: BigInt!
   amount: BigInt!
+  amountUSD: BigInt
   caller: Bytes!
   distributePayoutsEvent: DistributePayoutsEvent!
 
@@ -465,8 +488,11 @@ type UseAllowanceEvent @entity{
   fundingCycleNumber: Int!
   beneficiary: Bytes!
   amount: BigInt!
+  amountUSD: BigInt
   distributedAmount: BigInt!
+  distributedAmountUSD: BigInt
   netDistributedamount: BigInt!
+  netDistributedamountUSD: BigInt
   memo: String!
   caller: Bytes!
 }
@@ -609,7 +635,9 @@ type ProtocolV3Log @entity {
   log: ProtocolLog!
   projectsCount: Int!
   volumePaid: BigInt!
+  volumePaidUSD: BigInt!
   volumeRedeemed: BigInt!
+  volumeRedeemedUSD: BigInt!
   paymentsCount: Int!
   redeemCount: Int!
   erc20Count: Int!

--- a/schema.graphql
+++ b/schema.graphql
@@ -208,6 +208,7 @@ type RedeemEvent @entity {
   terminal: Bytes!
   timestamp: Int!
   txHash: Bytes!
+  metadata: Bytes # only v2/v3
 
   holder: Bytes!
   beneficiary: Bytes!

--- a/schema.graphql
+++ b/schema.graphql
@@ -60,6 +60,8 @@ type Project @entity {
 
   owner: Bytes!
   createdAt: Int!
+  paymentsCount: Int!
+  redeemCount: Int!
   totalPaid: BigInt!
   totalPaidUSD: BigInt!
   totalRedeemed: BigInt!
@@ -69,7 +71,8 @@ type Project @entity {
   trendingVolume: BigInt!
   trendingPaymentsCount: Int!
   createdWithinTrendingWindow: Boolean!
-  nftsMintedCount: Int!
+
+  nftsMintedCount: Int # only if project has jb721DelegateTokens
 
   # Derived fields
   participants: [Participant!]! @derivedFrom(field: "project")

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,8 @@
-import { BigInt } from "@graphprotocol/graph-ts";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 
 export const PROTOCOL_ID = "1";
 export const MAX_REDEMPTION_RATE = 10_000;
 export const BITS_8 = 0b11111111;
 export const BITS_16 = 0b1111111111111111;
 export const BIGINT_1 = BigInt.fromI32(1);
+export const ADDRESS_ZERO = Address.fromI32(0);

--- a/src/mappings/v1.x/projects.ts
+++ b/src/mappings/v1.x/projects.ts
@@ -1,4 +1,4 @@
-import { BigInt } from "@graphprotocol/graph-ts";
+import { BigInt, log } from "@graphprotocol/graph-ts";
 
 import {
   Create,
@@ -27,7 +27,12 @@ export function handleProjectCreate(event: Create): void {
   const pv = pvForTerminal(event.params.terminal);
   const projectId = idForProject(event.params.projectId, pv);
   const project = new Project(projectId);
-  if (!project) return;
+
+  if (!project) {
+    log.error("[handleProjectCreate] Missing project. ID:{}", [projectId]);
+    return;
+  }
+
   project.projectId = event.params.projectId.toI32();
   project.pv = pv;
   project.trendingScore = BigInt.fromString("0");
@@ -40,7 +45,9 @@ export function handleProjectCreate(event: Create): void {
   project.createdAt = event.block.timestamp.toI32();
   project.metadataUri = event.params.uri;
   project.totalPaid = BigInt.fromString("0");
+  project.totalPaidUSD = BigInt.fromString("0");
   project.totalRedeemed = BigInt.fromString("0");
+  project.totalRedeemedUSD = BigInt.fromString("0");
   project.currentBalance = BigInt.fromString("0");
   project.save();
 
@@ -84,7 +91,10 @@ export function handleSetHandle(event: SetHandle): void {
   const pv = pvForV1Project(event.params.projectId);
   const projectId = idForProject(event.params.projectId, pv);
   const project = Project.load(projectId);
-  if (!project) return;
+  if (!project) {
+    log.error("[handleProjectCreate] Missing project. ID:{}", [projectId]);
+    return;
+  }
   project.handle = event.params.handle.toString();
   project.save();
 }
@@ -93,15 +103,22 @@ export function handleSetUri(event: SetUri): void {
   const pv = pvForV1Project(event.params.projectId);
   const projectId = idForProject(event.params.projectId, pv);
   const project = Project.load(projectId);
-  if (!project) return;
+  if (!project) {
+    log.error("[handleProjectCreate] Missing project. ID:{}", [projectId]);
+    return;
+  }
   project.metadataUri = event.params.uri;
   project.save();
 }
 
 export function handleTransferOwnership(event: Transfer): void {
   const pv = pvForV1Project(event.params.tokenId);
-  const project = Project.load(idForProject(event.params.tokenId, pv));
-  if (!project) return;
+  const projectId = idForProject(event.params.tokenId, pv);
+  const project = Project.load(projectId);
+  if (!project) {
+    log.error("[handleProjectCreate] Missing project. ID:{}", [projectId]);
+    return;
+  }
   project.owner = event.params.to;
   project.save();
 }

--- a/src/mappings/v1.x/projects.ts
+++ b/src/mappings/v1.x/projects.ts
@@ -49,6 +49,8 @@ export function handleProjectCreate(event: Create): void {
   project.totalRedeemed = BigInt.fromString("0");
   project.totalRedeemedUSD = BigInt.fromString("0");
   project.currentBalance = BigInt.fromString("0");
+  project.paymentsCount = 0;
+  project.redeemCount = 0;
   project.save();
 
   const projectCreateEvent = new ProjectCreateEvent(

--- a/src/mappings/v1.x/terminalV1.ts
+++ b/src/mappings/v1.x/terminalV1.ts
@@ -61,6 +61,7 @@ export function handlePay(event: Pay): void {
   project.totalPaid = project.totalPaid.plus(event.params.amount);
   if (amountUSD) project.totalPaidUSD = project.totalPaidUSD.plus(amountUSD);
   project.currentBalance = project.currentBalance.plus(event.params.amount);
+  project.paymentsCount = project.paymentsCount + 1;
   project.save();
 
   if (pay) {
@@ -276,6 +277,7 @@ export function handleRedeem(event: Redeem): void {
     project.currentBalance = project.currentBalance.minus(
       event.params.returnAmount
     );
+    project.redeemCount = project.redeemCount + 1;
     project.save();
   }
 }

--- a/src/mappings/v1.x/terminalV1.ts
+++ b/src/mappings/v1.x/terminalV1.ts
@@ -39,6 +39,7 @@ import {
   idForProject,
   idForProjectTx,
 } from "../../utils/ids";
+import { v1USDPriceForEth } from "../../utils/prices";
 import { pvForV1Project } from "../../utils/pv";
 import { handleTrendingPayment } from "../../utils/trending";
 
@@ -56,7 +57,9 @@ export function handlePay(event: Pay): void {
     return;
   }
 
+  const amountUSD = v1USDPriceForEth(event.params.amount);
   project.totalPaid = project.totalPaid.plus(event.params.amount);
+  if (amountUSD) project.totalPaidUSD = project.totalPaidUSD.plus(amountUSD);
   project.currentBalance = project.currentBalance.plus(event.params.amount);
   project.save();
 
@@ -65,6 +68,7 @@ export function handlePay(event: Pay): void {
     pay.terminal = terminal;
     pay.projectId = event.params.projectId.toI32();
     pay.amount = event.params.amount;
+    pay.amountUSD = amountUSD;
     pay.beneficiary = event.params.beneficiary;
     pay.caller = event.transaction.from;
     pay.project = projectId;
@@ -91,6 +95,9 @@ export function handlePay(event: Pay): void {
     protocolV1Log.volumePaid = protocolV1Log.volumePaid.plus(
       event.params.amount
     );
+    if (amountUSD) {
+      protocolV1Log.volumePaidUSD = protocolV1Log.volumePaidUSD.plus(amountUSD);
+    }
     protocolV1Log.paymentsCount = protocolV1Log.paymentsCount + 1;
     protocolV1Log.save();
   }
@@ -109,7 +116,12 @@ export function handlePay(event: Pay): void {
       event.params.beneficiary
     );
   } else {
-    participant.totalPaid = event.params.amount.plus(participant.totalPaid);
+    participant.totalPaid = participant.totalPaid = participant.totalPaid.plus(
+      event.params.amount
+    );
+    if (amountUSD) {
+      participant.totalPaidUSD = participant.totalPaidUSD.plus(amountUSD);
+    }
   }
   participant.lastPaidTimestamp = event.block.timestamp.toI32();
   participant.save();
@@ -156,15 +168,26 @@ export function handleTap(event: Tap): void {
   const tapEvent = new TapEvent(
     idForProjectTx(event.params.projectId, pv, event)
   );
+
+  const amountUSD = v1USDPriceForEth(event.params.amount);
+
   if (tapEvent) {
     tapEvent.amount = event.params.amount;
+    tapEvent.amountUSD = amountUSD;
     tapEvent.beneficiary = event.params.beneficiary;
     tapEvent.beneficiaryTransferAmount = event.params.beneficiaryTransferAmount;
+    tapEvent.beneficiaryTransferAmountUSD = v1USDPriceForEth(
+      event.params.beneficiaryTransferAmount
+    );
     tapEvent.caller = event.transaction.from;
     tapEvent.currency = event.params.currency;
     tapEvent.fundingCycleId = event.params.fundingCycleId;
     tapEvent.govFeeAmount = event.params.govFeeAmount;
+    tapEvent.govFeeAmountUSD = v1USDPriceForEth(event.params.govFeeAmount);
     tapEvent.netTransferAmount = event.params.netTransferAmount;
+    tapEvent.netTransferAmountUSD = v1USDPriceForEth(
+      event.params.netTransferAmount
+    );
     tapEvent.project = projectId;
     tapEvent.projectId = event.params.projectId.toI32();
     tapEvent.timestamp = event.block.timestamp.toI32();
@@ -197,6 +220,7 @@ export function handleRedeem(event: Redeem): void {
   const redeemEvent = new RedeemEvent(
     idForProjectTx(event.params._projectId, pv, event, true)
   );
+  const returnAmountUSD = v1USDPriceForEth(event.params.returnAmount);
   if (redeemEvent) {
     redeemEvent.projectId = event.params._projectId.toI32();
     redeemEvent.pv = pv;
@@ -206,6 +230,7 @@ export function handleRedeem(event: Redeem): void {
     redeemEvent.caller = event.transaction.from;
     redeemEvent.holder = event.params.holder;
     redeemEvent.returnAmount = event.params.returnAmount;
+    redeemEvent.returnAmountUSD = returnAmountUSD;
     redeemEvent.project = projectId;
     redeemEvent.timestamp = event.block.timestamp.toI32();
     redeemEvent.txHash = event.transaction.hash;
@@ -225,8 +250,13 @@ export function handleRedeem(event: Redeem): void {
   if (!protocolV1Log) protocolV1Log = new ProtocolV1Log(PROTOCOL_ID);
   if (protocolV1Log) {
     protocolV1Log.volumeRedeemed = protocolV1Log.volumeRedeemed.plus(
-      event.params.amount
+      event.params.returnAmount
     );
+    if (returnAmountUSD) {
+      protocolV1Log.volumeRedeemedUSD = protocolV1Log.volumeRedeemedUSD.plus(
+        returnAmountUSD
+      );
+    }
     protocolV1Log.redeemCount = protocolV1Log.redeemCount + 1;
     protocolV1Log.save();
   }
@@ -237,6 +267,12 @@ export function handleRedeem(event: Redeem): void {
     project.totalRedeemed = project.totalRedeemed.plus(
       event.params.returnAmount
     );
+    const amountRedeemedUSD = v1USDPriceForEth(event.params.returnAmount);
+    if (amountRedeemedUSD) {
+      project.totalRedeemedUSD = project.totalRedeemedUSD.plus(
+        amountRedeemedUSD
+      );
+    }
     project.currentBalance = project.currentBalance.minus(
       event.params.returnAmount
     );
@@ -296,6 +332,7 @@ export function handleAddToBalance(event: AddToBalance): void {
     addToBalance.terminal = terminal;
     addToBalance.projectId = event.params.projectId.toI32();
     addToBalance.amount = event.params.value;
+    addToBalance.amountUSD = v1USDPriceForEth(event.params.value);
     addToBalance.caller = event.transaction.from;
     addToBalance.project = projectId;
     addToBalance.timestamp = event.block.timestamp.toI32();
@@ -338,6 +375,7 @@ export function handleDistributeToPayoutMod(
   distributeToPayoutModEvent.modPreferUnstaked =
     event.params.mod.preferUnstaked;
   distributeToPayoutModEvent.modCut = event.params.modCut;
+  distributeToPayoutModEvent.modCutUSD = v1USDPriceForEth(event.params.modCut);
   distributeToPayoutModEvent.timestamp = event.block.timestamp.toI32();
   distributeToPayoutModEvent.txHash = event.transaction.hash;
 
@@ -395,7 +433,10 @@ export function handleMigrate(event: Migrate): void {
   const pv = pvForV1Project(event.params.projectId);
   const projectId = idForProject(event.params.projectId, pv);
   const project = Project.load(projectId);
-  if (!project) return;
+  if (!project) {
+    log.error("[handleMigrate] Missing project. ID:{}", [projectId]);
+    return;
+  }
   project.terminal = event.params.to;
   project.save();
 }

--- a/src/mappings/v1.x/terminalV1_1.ts
+++ b/src/mappings/v1.x/terminalV1_1.ts
@@ -60,6 +60,7 @@ export function handlePay(event: Pay): void {
   project.totalPaid = project.totalPaid.plus(event.params.amount);
   if (amountUSD) project.totalPaidUSD = project.totalPaidUSD.plus(amountUSD);
   project.currentBalance = project.currentBalance.plus(event.params.amount);
+  project.paymentsCount = project.paymentsCount + 1;
   project.save();
 
   if (pay) {
@@ -268,6 +269,7 @@ export function handleRedeem(event: Redeem): void {
     project.currentBalance = project.currentBalance.minus(
       event.params.returnAmount
     );
+    project.redeemCount = project.redeemCount + 1;
     project.save();
   }
 }

--- a/src/mappings/v1.x/terminalV1_1.ts
+++ b/src/mappings/v1.x/terminalV1_1.ts
@@ -38,6 +38,7 @@ import {
   idForProject,
   idForProjectTx,
 } from "../../utils/ids";
+import { v1USDPriceForEth } from "../../utils/prices";
 import { pvForV1Project } from "../../utils/pv";
 import { handleTrendingPayment } from "../../utils/trending";
 
@@ -55,7 +56,9 @@ export function handlePay(event: Pay): void {
     return;
   }
 
+  const amountUSD = v1USDPriceForEth(event.params.amount);
   project.totalPaid = project.totalPaid.plus(event.params.amount);
+  if (amountUSD) project.totalPaidUSD = project.totalPaidUSD.plus(amountUSD);
   project.currentBalance = project.currentBalance.plus(event.params.amount);
   project.save();
 
@@ -64,6 +67,7 @@ export function handlePay(event: Pay): void {
     pay.terminal = terminal;
     pay.projectId = event.params.projectId.toI32();
     pay.amount = event.params.amount;
+    pay.amountUSD = amountUSD;
     pay.beneficiary = event.params.beneficiary;
     pay.caller = event.transaction.from;
     pay.project = projectId;
@@ -90,6 +94,9 @@ export function handlePay(event: Pay): void {
     protocolV1Log.volumePaid = protocolV1Log.volumePaid.plus(
       event.params.amount
     );
+    if (amountUSD) {
+      protocolV1Log.volumePaidUSD = protocolV1Log.volumePaidUSD.plus(amountUSD);
+    }
     protocolV1Log.paymentsCount = protocolV1Log.paymentsCount + 1;
     protocolV1Log.save();
   }
@@ -108,7 +115,10 @@ export function handlePay(event: Pay): void {
       event.params.beneficiary
     );
   } else {
-    participant.totalPaid = event.params.amount.plus(participant.totalPaid);
+    participant.totalPaid = participant.totalPaid.plus(event.params.amount);
+    if (amountUSD) {
+      participant.totalPaidUSD = participant.totalPaidUSD.plus(amountUSD);
+    }
   }
   participant.lastPaidTimestamp = event.block.timestamp.toI32();
   participant.save();
@@ -127,7 +137,9 @@ export function handlePrintTickets(event: PrintTickets): void {
     idForProjectTx(event.params.projectId, pv, event, true)
   );
   const projectId = idForProject(event.params.projectId, pv);
+
   if (!mintTokensEvent) return;
+
   mintTokensEvent.pv = pv;
   mintTokensEvent.projectId = event.params.projectId.toI32();
   mintTokensEvent.amount = event.params.amount;
@@ -155,15 +167,21 @@ export function handleTap(event: Tap): void {
   const tapEvent = new TapEvent(
     idForProjectTx(event.params.projectId, pv, event)
   );
+
   if (tapEvent) {
     tapEvent.amount = event.params.amount;
+    tapEvent.amountUSD = v1USDPriceForEth(event.params.amount);
     tapEvent.beneficiary = event.params.beneficiary;
     tapEvent.beneficiaryTransferAmount = event.params.beneficiaryTransferAmount;
     tapEvent.caller = event.transaction.from;
     tapEvent.currency = event.params.currency;
     tapEvent.fundingCycleId = event.params.fundingCycleId;
     tapEvent.govFeeAmount = event.params.govFeeAmount;
+    tapEvent.govFeeAmountUSD = v1USDPriceForEth(event.params.govFeeAmount);
     tapEvent.netTransferAmount = event.params.netTransferAmount;
+    tapEvent.netTransferAmountUSD = v1USDPriceForEth(
+      event.params.netTransferAmount
+    );
     tapEvent.project = projectId;
     tapEvent.projectId = event.params.projectId.toI32();
     tapEvent.timestamp = event.block.timestamp.toI32();
@@ -193,6 +211,8 @@ export function handleRedeem(event: Redeem): void {
   const pv = pvForV1Project(event.params._projectId);
   const projectId = idForProject(event.params._projectId, pv);
 
+  const returnAmountUSD = v1USDPriceForEth(event.params.returnAmount);
+
   const redeemEvent = new RedeemEvent(
     idForProjectTx(event.params._projectId, pv, event, true)
   );
@@ -205,6 +225,7 @@ export function handleRedeem(event: Redeem): void {
     redeemEvent.caller = event.transaction.from;
     redeemEvent.holder = event.params.holder;
     redeemEvent.returnAmount = event.params.returnAmount;
+    redeemEvent.returnAmountUSD = returnAmountUSD;
     redeemEvent.project = projectId;
     redeemEvent.timestamp = event.block.timestamp.toI32();
     redeemEvent.txHash = event.transaction.hash;
@@ -224,8 +245,13 @@ export function handleRedeem(event: Redeem): void {
   if (!protocolV1Log) protocolV1Log = newProtocolV1Log();
   if (protocolV1Log) {
     protocolV1Log.volumeRedeemed = protocolV1Log.volumeRedeemed.plus(
-      event.params.amount
+      event.params.returnAmount
     );
+    if (returnAmountUSD) {
+      protocolV1Log.volumeRedeemedUSD = protocolV1Log.volumeRedeemedUSD.plus(
+        returnAmountUSD
+      );
+    }
     protocolV1Log.redeemCount = protocolV1Log.redeemCount + 1;
     protocolV1Log.save();
   }
@@ -236,6 +262,9 @@ export function handleRedeem(event: Redeem): void {
     project.totalRedeemed = project.totalRedeemed.plus(
       event.params.returnAmount
     );
+    if (returnAmountUSD) {
+      project.totalRedeemedUSD = project.totalRedeemedUSD.plus(returnAmountUSD);
+    }
     project.currentBalance = project.currentBalance.minus(
       event.params.returnAmount
     );
@@ -295,6 +324,7 @@ export function handleAddToBalance(event: AddToBalance): void {
     addToBalance.terminal = terminal;
     addToBalance.projectId = event.params.projectId.toI32();
     addToBalance.amount = event.params.value;
+    addToBalance.amountUSD = v1USDPriceForEth(event.params.value);
     addToBalance.caller = event.transaction.from;
     addToBalance.project = projectId;
     addToBalance.timestamp = event.block.timestamp.toI32();
@@ -320,7 +350,9 @@ export function handleDistributeToPayoutMod(
     idForProjectTx(event.params.projectId, pv, event, true)
   );
   const projectId = idForProject(event.params.projectId, pv);
+
   if (!distributeToPayoutModEvent) return;
+
   distributeToPayoutModEvent.projectId = event.params.projectId.toI32();
   distributeToPayoutModEvent.tapEvent = idForProjectTx(
     event.params.projectId,
@@ -337,6 +369,7 @@ export function handleDistributeToPayoutMod(
   distributeToPayoutModEvent.modPreferUnstaked =
     event.params.mod.preferUnstaked;
   distributeToPayoutModEvent.modCut = event.params.modCut;
+  distributeToPayoutModEvent.modCutUSD = v1USDPriceForEth(event.params.modCut);
   distributeToPayoutModEvent.timestamp = event.block.timestamp.toI32();
   distributeToPayoutModEvent.txHash = event.transaction.hash;
 
@@ -362,6 +395,7 @@ export function handleDistributeToTicketMod(
   const projectId = idForProject(event.params.projectId, pv);
 
   if (!distributeToTicketModEvent) return;
+
   distributeToTicketModEvent.printReservesEvent = idForProjectTx(
     event.params.projectId,
     pv,

--- a/src/mappings/v1.x/ticketBooth.ts
+++ b/src/mappings/v1.x/ticketBooth.ts
@@ -171,7 +171,10 @@ export function handleIssue(event: Issue): void {
   const projectId = idForProject(event.params.projectId, pv);
   const project = Project.load(projectId);
 
-  if (!project) return;
+  if (!project) {
+    log.error("[handleIssue] Missing project. ID:{}", [projectId]);
+    return;
+  }
 
   const deployedERC20Event = new DeployedERC20Event(
     idForProjectTx(event.params.projectId, pv, event)

--- a/src/mappings/v2/jbController.ts
+++ b/src/mappings/v2/jbController.ts
@@ -137,7 +137,10 @@ export function handleDistributeToReservedTokenSplit(
 export function handleMigrate(event: Migrate): void {
   const projectId = idForProject(event.params.projectId, pv);
   const project = Project.load(projectId);
-  if (!project) return;
+  if (!project) {
+    log.error("[handleMigrate] Missing project. ID:{}", [projectId]);
+    return;
+  }
   project.pv = pv;
   project.save();
 }

--- a/src/mappings/v2/jbETHPaymentTerminal.ts
+++ b/src/mappings/v2/jbETHPaymentTerminal.ts
@@ -292,6 +292,7 @@ export function handleRedeemTokens(event: RedeemTokens): void {
     redeemEvent.project = projectId;
     redeemEvent.timestamp = event.block.timestamp.toI32();
     redeemEvent.txHash = event.transaction.hash;
+    redeemEvent.metadata = event.params.metadata;
     redeemEvent.save();
 
     saveNewProjectTerminalEvent(

--- a/src/mappings/v2/jbETHPaymentTerminal.ts
+++ b/src/mappings/v2/jbETHPaymentTerminal.ts
@@ -204,6 +204,7 @@ export function handlePay(event: Pay): void {
 
   project.totalPaid = project.totalPaid.plus(event.params.amount);
   project.currentBalance = project.currentBalance.plus(event.params.amount);
+  project.paymentsCount = project.paymentsCount + 1;
   project.save();
 
   if (pay) {
@@ -338,6 +339,7 @@ export function handleRedeemTokens(event: RedeemTokens): void {
   project.currentBalance = project.currentBalance.minus(
     event.params.reclaimedAmount
   );
+  project.redeemCount = project.redeemCount + 1;
   project.save();
 }
 

--- a/src/mappings/v2/jbETHPaymentTerminal.ts
+++ b/src/mappings/v2/jbETHPaymentTerminal.ts
@@ -36,6 +36,7 @@ import {
   idForProject,
   idForProjectTx,
 } from "../../utils/ids";
+import { v2USDPriceForEth } from "../../utils/prices";
 import { handleTrendingPayment } from "../../utils/trending";
 
 const pv: Version = "2";
@@ -63,6 +64,7 @@ export function handleAddToBalance(event: AddToBalance): void {
     addToBalance.terminal = terminal;
     addToBalance.projectId = event.params.projectId.toI32();
     addToBalance.amount = event.params.amount;
+    addToBalance.amountUSD = v2USDPriceForEth(event.params.amount);
     addToBalance.caller = event.transaction.from;
     addToBalance.project = projectId;
     addToBalance.note = event.params.memo;
@@ -85,6 +87,7 @@ export function handleDistributePayouts(event: DistributePayouts): void {
   const distributePayoutsEvent = new DistributePayoutsEvent(
     idForProjectTx(event.params.projectId, pv, event)
   );
+
   if (!distributePayoutsEvent) {
     log.error(
       "[handleDistributePayouts] Missing distributePayoutsEvent. ID:{}",
@@ -99,12 +102,17 @@ export function handleDistributePayouts(event: DistributePayouts): void {
   distributePayoutsEvent.timestamp = event.block.timestamp.toI32();
   distributePayoutsEvent.txHash = event.transaction.hash;
   distributePayoutsEvent.amount = event.params.amount;
+  distributePayoutsEvent.amountUSD = v2USDPriceForEth(event.params.amount);
   distributePayoutsEvent.beneficiary = event.params.beneficiary;
   distributePayoutsEvent.beneficiaryDistributionAmount =
     event.params.beneficiaryDistributionAmount;
+  distributePayoutsEvent.beneficiaryDistributionAmountUSD =
+    event.params.beneficiaryDistributionAmount;
   distributePayoutsEvent.caller = event.transaction.from;
   distributePayoutsEvent.distributedAmount = event.params.distributedAmount;
+  distributePayoutsEvent.distributedAmountUSD = event.params.distributedAmount;
   distributePayoutsEvent.fee = event.params.fee;
+  distributePayoutsEvent.feeUSD = v2USDPriceForEth(event.params.fee);
   distributePayoutsEvent.fundingCycleConfiguration =
     event.params.fundingCycleConfiguration;
   distributePayoutsEvent.fundingCycleNumber = event.params.fundingCycleNumber.toI32();
@@ -156,6 +164,7 @@ export function handleDistributeToPayoutSplit(
   distributePayoutSplitEvent.txHash = event.transaction.hash;
   distributePayoutSplitEvent.timestamp = event.block.timestamp.toI32();
   distributePayoutSplitEvent.amount = event.params.amount;
+  distributePayoutSplitEvent.amountUSD = v2USDPriceForEth(event.params.amount);
   distributePayoutSplitEvent.caller = event.transaction.from;
   distributePayoutSplitEvent.domain = event.params.domain;
   distributePayoutSplitEvent.group = event.params.group;
@@ -191,6 +200,8 @@ export function handlePay(event: Pay): void {
     return;
   }
 
+  const amountUSD = v2USDPriceForEth(event.params.amount);
+
   project.totalPaid = project.totalPaid.plus(event.params.amount);
   project.currentBalance = project.currentBalance.plus(event.params.amount);
   project.save();
@@ -200,6 +211,7 @@ export function handlePay(event: Pay): void {
     pay.terminal = terminal;
     pay.projectId = event.params.projectId.toI32();
     pay.amount = event.params.amount;
+    pay.amountUSD = amountUSD;
     pay.beneficiary = event.params.beneficiary;
     pay.caller = event.transaction.from;
     pay.project = projectId;
@@ -220,17 +232,22 @@ export function handlePay(event: Pay): void {
     handleTrendingPayment(event.block.timestamp);
   }
 
+  // Update protocol log
   let protocolV2Log = ProtocolV2Log.load(PROTOCOL_ID);
   if (!protocolV2Log) protocolV2Log = newProtocolV2Log();
   if (protocolV2Log) {
     protocolV2Log.volumePaid = protocolV2Log.volumePaid.plus(
       event.params.amount
     );
+    if (amountUSD) {
+      protocolV2Log.volumePaidUSD = protocolV2Log.volumePaidUSD.plus(amountUSD);
+    }
     protocolV2Log.paymentsCount = protocolV2Log.paymentsCount + 1;
     protocolV2Log.save();
   }
   updateProtocolEntity();
 
+  // Update participant
   const participantId = idForParticipant(
     event.params.projectId,
     pv,
@@ -244,7 +261,10 @@ export function handlePay(event: Pay): void {
       event.params.beneficiary
     );
   } else {
-    participant.totalPaid = event.params.amount.plus(participant.totalPaid);
+    participant.totalPaid = participant.totalPaid.plus(event.params.amount);
+    if (amountUSD) {
+      participant.totalPaidUSD = participant.totalPaidUSD.plus(amountUSD);
+    }
   }
   participant.lastPaidTimestamp = event.block.timestamp.toI32();
   participant.save();
@@ -256,6 +276,9 @@ export function handleRedeemTokens(event: RedeemTokens): void {
   const redeemEvent = new RedeemEvent(
     idForProjectTx(event.params.projectId, pv, event, true)
   );
+
+  const reclaimedAmountUSD = v2USDPriceForEth(event.params.reclaimedAmount);
+
   if (redeemEvent) {
     redeemEvent.projectId = event.params.projectId.toI32();
     redeemEvent.pv = pv;
@@ -265,6 +288,7 @@ export function handleRedeemTokens(event: RedeemTokens): void {
     redeemEvent.caller = event.transaction.from;
     redeemEvent.holder = event.params.holder;
     redeemEvent.returnAmount = event.params.reclaimedAmount;
+    redeemEvent.returnAmountUSD = reclaimedAmountUSD;
     redeemEvent.project = projectId;
     redeemEvent.timestamp = event.block.timestamp.toI32();
     redeemEvent.txHash = event.transaction.hash;
@@ -283,8 +307,13 @@ export function handleRedeemTokens(event: RedeemTokens): void {
     if (!protocolV2Log) protocolV2Log = newProtocolV2Log();
     if (protocolV2Log) {
       protocolV2Log.volumeRedeemed = protocolV2Log.volumeRedeemed.plus(
-        event.params.tokenCount
+        event.params.reclaimedAmount
       );
+      if (reclaimedAmountUSD) {
+        protocolV2Log.volumeRedeemedUSD = protocolV2Log.volumeRedeemedUSD.plus(
+          reclaimedAmountUSD
+        );
+      }
       protocolV2Log.redeemCount = protocolV2Log.redeemCount + 1;
       protocolV2Log.save();
     }
@@ -296,9 +325,15 @@ export function handleRedeemTokens(event: RedeemTokens): void {
     log.error("[handleRedeemTokens] Missing project. ID:{}", [projectId]);
     return;
   }
+
   project.totalRedeemed = project.totalRedeemed.plus(
     event.params.reclaimedAmount
   );
+  if (reclaimedAmountUSD) {
+    project.totalRedeemedUSD = project.totalRedeemedUSD.plus(
+      reclaimedAmountUSD
+    );
+  }
   project.currentBalance = project.currentBalance.minus(
     event.params.reclaimedAmount
   );
@@ -318,19 +353,28 @@ export function handleUseAllowance(event: UseAllowance): void {
     return;
   }
 
+  const amountUSD = v2USDPriceForEth(event.params.amount);
+  const distributedAmountUSD = v2USDPriceForEth(event.params.distributedAmount);
+  const netDistributedamountUSD = v2USDPriceForEth(
+    event.params.netDistributedamount
+  );
+
   useAllowanceEvent.project = projectId;
   useAllowanceEvent.projectId = event.params.projectId.toI32();
   useAllowanceEvent.timestamp = event.block.timestamp.toI32();
   useAllowanceEvent.txHash = event.transaction.hash;
   useAllowanceEvent.amount = event.params.amount;
+  useAllowanceEvent.amountUSD = amountUSD;
   useAllowanceEvent.beneficiary = event.params.beneficiary;
   useAllowanceEvent.caller = event.transaction.from;
   useAllowanceEvent.distributedAmount = event.params.distributedAmount;
+  useAllowanceEvent.distributedAmountUSD = distributedAmountUSD;
   useAllowanceEvent.fundingCycleConfiguration =
     event.params.fundingCycleConfiguration;
   useAllowanceEvent.fundingCycleNumber = event.params.fundingCycleNumber.toI32();
   useAllowanceEvent.memo = event.params.memo;
   useAllowanceEvent.netDistributedamount = event.params.netDistributedamount;
+  useAllowanceEvent.netDistributedamountUSD = netDistributedamountUSD;
   useAllowanceEvent.save();
 
   saveNewProjectTerminalEvent(

--- a/src/mappings/v2/jbProjects.ts
+++ b/src/mappings/v2/jbProjects.ts
@@ -44,7 +44,9 @@ export function handleCreate(event: Create): void {
   project.metadataUri = event.params.metadata.content;
   project.metadataDomain = event.params.metadata.domain;
   project.totalPaid = BigInt.fromString("0");
+  project.totalPaidUSD = BigInt.fromString("0");
   project.totalRedeemed = BigInt.fromString("0");
+  project.totalRedeemedUSD = BigInt.fromString("0");
   project.currentBalance = BigInt.fromString("0");
   project.save();
 

--- a/src/mappings/v2/jbProjects.ts
+++ b/src/mappings/v2/jbProjects.ts
@@ -48,6 +48,8 @@ export function handleCreate(event: Create): void {
   project.totalRedeemed = BigInt.fromString("0");
   project.totalRedeemedUSD = BigInt.fromString("0");
   project.currentBalance = BigInt.fromString("0");
+  project.paymentsCount = 0;
+  project.redeemCount = 0;
   project.save();
 
   const projectCreateEvent = new ProjectCreateEvent(

--- a/src/mappings/v3/jbETHPaymentTerminal.ts
+++ b/src/mappings/v3/jbETHPaymentTerminal.ts
@@ -294,6 +294,7 @@ export function handleRedeemTokens(event: RedeemTokens): void {
     redeemEvent.project = projectId;
     redeemEvent.timestamp = event.block.timestamp.toI32();
     redeemEvent.txHash = event.transaction.hash;
+    redeemEvent.metadata = event.params.metadata;
     redeemEvent.save();
 
     saveNewProjectTerminalEvent(

--- a/src/mappings/v3/jbETHPaymentTerminal.ts
+++ b/src/mappings/v3/jbETHPaymentTerminal.ts
@@ -208,6 +208,7 @@ export function handlePay(event: Pay): void {
   project.totalPaid = project.totalPaid.plus(event.params.amount);
   if (amountUSD) project.totalPaidUSD = project.totalPaidUSD.plus(amountUSD);
   project.currentBalance = project.currentBalance.plus(event.params.amount);
+  project.paymentsCount = project.paymentsCount + 1;
   project.save();
 
   if (pay) {
@@ -339,6 +340,7 @@ export function handleRedeemTokens(event: RedeemTokens): void {
   project.currentBalance = project.currentBalance.minus(
     event.params.reclaimedAmount
   );
+  project.redeemCount = project.redeemCount + 1;
   project.save();
 }
 

--- a/src/mappings/veNft/veNftDeployer.ts
+++ b/src/mappings/veNft/veNftDeployer.ts
@@ -10,12 +10,16 @@ import {
   idForVeNftContract,
 } from "../../utils/ids";
 import { JBVeNft } from "../../../generated/templates";
+import { log } from "@graphprotocol/graph-ts";
 
 export function handleDeployVeNft(event: DeployVeNft): void {
   const pv = "2";
   const projectId = idForProject(event.params.projectId, pv);
   const project = Project.load(projectId);
-  if (!project) return;
+  if (!project) {
+    log.error("[handlePay] Missing project. ID:{}", [projectId]);
+    return;
+  }
 
   const deployVeNftEvent = new DeployVeNftEvent(
     idForProjectTx(event.params.projectId, pv, event)

--- a/src/utils/entities/participant.ts
+++ b/src/utils/entities/participant.ts
@@ -17,6 +17,7 @@ export function newParticipant(
   participant.stakedBalance = BigInt.fromString("0");
   participant.unstakedBalance = BigInt.fromString("0");
   participant.totalPaid = BigInt.fromString("0");
+  participant.totalPaidUSD = BigInt.fromString("0");
   participant.lastPaidTimestamp = 0;
   return participant;
 }

--- a/src/utils/entities/protocolLog.ts
+++ b/src/utils/entities/protocolLog.ts
@@ -11,7 +11,9 @@ export function newProtocolLog(): ProtocolLog {
   const protocolLog = new ProtocolLog(PROTOCOL_ID);
   protocolLog.projectsCount = 0;
   protocolLog.volumePaid = BigInt.fromString("0");
+  protocolLog.volumePaidUSD = BigInt.fromString("0");
   protocolLog.volumeRedeemed = BigInt.fromString("0");
+  protocolLog.volumeRedeemedUSD = BigInt.fromString("0");
   protocolLog.paymentsCount = 0;
   protocolLog.redeemCount = 0;
   protocolLog.erc20Count = 0;
@@ -24,7 +26,9 @@ export function newProtocolV1Log(): ProtocolV1Log {
   protocolV1Log.log = PROTOCOL_ID;
   protocolV1Log.projectsCount = 0;
   protocolV1Log.volumePaid = BigInt.fromString("0");
+  protocolV1Log.volumePaidUSD = BigInt.fromString("0");
   protocolV1Log.volumeRedeemed = BigInt.fromString("0");
+  protocolV1Log.volumeRedeemedUSD = BigInt.fromString("0");
   protocolV1Log.paymentsCount = 0;
   protocolV1Log.redeemCount = 0;
   protocolV1Log.erc20Count = 0;
@@ -36,7 +40,9 @@ export function newProtocolV2Log(): ProtocolV2Log {
   protocolV2Log.log = PROTOCOL_ID;
   protocolV2Log.projectsCount = 0;
   protocolV2Log.volumePaid = BigInt.fromString("0");
+  protocolV2Log.volumePaidUSD = BigInt.fromString("0");
   protocolV2Log.volumeRedeemed = BigInt.fromString("0");
+  protocolV2Log.volumeRedeemedUSD = BigInt.fromString("0");
   protocolV2Log.paymentsCount = 0;
   protocolV2Log.redeemCount = 0;
   protocolV2Log.erc20Count = 0;
@@ -48,7 +54,9 @@ export function newProtocolV3Log(): ProtocolV3Log {
   protocolV3Log.log = PROTOCOL_ID;
   protocolV3Log.projectsCount = 0;
   protocolV3Log.volumePaid = BigInt.fromString("0");
+  protocolV3Log.volumePaidUSD = BigInt.fromString("0");
   protocolV3Log.volumeRedeemed = BigInt.fromString("0");
+  protocolV3Log.volumeRedeemedUSD = BigInt.fromString("0");
   protocolV3Log.paymentsCount = 0;
   protocolV3Log.redeemCount = 0;
   protocolV3Log.erc20Count = 0;
@@ -67,7 +75,9 @@ export function updateProtocolEntity(): void {
 
   let projectsCount = 0;
   let volumePaid = BigInt.fromString("0");
+  let volumePaidUSD = BigInt.fromString("0");
   let volumeRedeemed = BigInt.fromString("0");
+  let volumeRedeemedUSD = BigInt.fromString("0");
   let paymentsCount = 0;
   let redeemCount = 0;
   let erc20Count = 0;
@@ -79,7 +89,9 @@ export function updateProtocolEntity(): void {
     projectsCount = projectsCount + protocolV1Log.projectsCount;
     redeemCount = redeemCount + protocolV1Log.redeemCount;
     volumePaid = volumePaid.plus(protocolV1Log.volumePaid);
+    volumePaidUSD = volumePaidUSD.plus(protocolV1Log.volumePaidUSD);
     volumeRedeemed = volumeRedeemed.plus(protocolV1Log.volumeRedeemed);
+    volumeRedeemedUSD = volumeRedeemedUSD.plus(protocolV1Log.volumeRedeemedUSD);
   }
 
   const protocolV2Log = ProtocolV2Log.load(PROTOCOL_ID);
@@ -89,7 +101,9 @@ export function updateProtocolEntity(): void {
     projectsCount = projectsCount + protocolV2Log.projectsCount;
     redeemCount = redeemCount + protocolV2Log.redeemCount;
     volumePaid = volumePaid.plus(protocolV2Log.volumePaid);
+    volumePaidUSD = volumePaidUSD.plus(protocolV2Log.volumePaidUSD);
     volumeRedeemed = volumeRedeemed.plus(protocolV2Log.volumeRedeemed);
+    volumeRedeemedUSD = volumeRedeemedUSD.plus(protocolV2Log.volumeRedeemedUSD);
   }
 
   const protocolV3Log = ProtocolV3Log.load(PROTOCOL_ID);
@@ -99,7 +113,9 @@ export function updateProtocolEntity(): void {
     projectsCount = projectsCount + protocolV3Log.projectsCount;
     redeemCount = redeemCount + protocolV3Log.redeemCount;
     volumePaid = volumePaid.plus(protocolV3Log.volumePaid);
+    volumePaidUSD = volumePaidUSD.plus(protocolV3Log.volumePaidUSD);
     volumeRedeemed = volumeRedeemed.plus(protocolV3Log.volumeRedeemed);
+    volumeRedeemedUSD = volumeRedeemedUSD.plus(protocolV3Log.volumeRedeemedUSD);
   }
 
   protocolLog.erc20Count = erc20Count;
@@ -107,6 +123,8 @@ export function updateProtocolEntity(): void {
   protocolLog.projectsCount = projectsCount;
   protocolLog.redeemCount = redeemCount;
   protocolLog.volumePaid = volumePaid;
+  protocolLog.volumePaidUSD = volumePaidUSD;
   protocolLog.volumeRedeemed = volumeRedeemed;
+  protocolLog.volumeRedeemedUSD = volumeRedeemedUSD;
   protocolLog.save();
 }

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -1,0 +1,70 @@
+import {
+  address_v1_prices,
+  address_v2_jbPrices,
+  address_v3_jbPrices,
+} from "../contractAddresses";
+import { Prices } from "../../generated/TerminalV1/Prices";
+import { JBPrices as V2JBPrices } from "../../generated/V2JBETHPaymentTerminal/JBPrices";
+import { JBPrices as V3JBPrices } from "../../generated/V3JBETHPaymentTerminal/JBPrices";
+import { Address, BigInt, Bytes, log } from "@graphprotocol/graph-ts";
+
+const V1_CURRENCY_USD = BigInt.fromI32(1);
+const V2V3_CURRENCY_ETH = BigInt.fromI32(1);
+const V2V3_CURRENCY_USD = BigInt.fromI32(2);
+const BIGINT_WAD = BigInt.fromString("1000000000000000000");
+
+export function v1USDPriceForEth(ethAmount: BigInt): BigInt | null {
+  if (!address_v1_prices) return null;
+
+  const pricesContract = Prices.bind(
+    Address.fromBytes(Bytes.fromHexString(address_v1_prices!))
+  );
+
+  const priceForCall = pricesContract.try_getETHPriceFor(V1_CURRENCY_USD);
+  if (priceForCall.reverted) {
+    log.error("[v1USDPriceForEth] getETHPriceFor() reverted", []);
+    return null;
+  }
+
+  return ethAmount.times(priceForCall.value).div(BIGINT_WAD);
+}
+
+export function v2USDPriceForEth(ethAmount: BigInt): BigInt | null {
+  if (!address_v2_jbPrices) return null;
+
+  const pricesContract = V2JBPrices.bind(
+    Address.fromBytes(Bytes.fromHexString(address_v2_jbPrices!))
+  );
+
+  const priceForCall = pricesContract.try_priceFor(
+    V2V3_CURRENCY_ETH,
+    V2V3_CURRENCY_USD,
+    BigInt.fromI32(18)
+  );
+  if (priceForCall.reverted) {
+    log.error("[v2USDPriceForEth] priceFor() reverted", []);
+    return null;
+  }
+
+  return ethAmount.times(priceForCall.value).div(BIGINT_WAD);
+}
+
+export function v3USDPriceForEth(ethAmount: BigInt): BigInt | null {
+  if (!address_v3_jbPrices) return null;
+
+  const pricesContract = V3JBPrices.bind(
+    Address.fromBytes(Bytes.fromHexString(address_v3_jbPrices!))
+  );
+
+  const priceForCall = pricesContract.try_priceFor(
+    V2V3_CURRENCY_ETH,
+    V2V3_CURRENCY_USD,
+    BigInt.fromI32(18)
+  );
+  if (priceForCall.reverted) {
+    log.error("[v3USDPriceForEth] priceFor() reverted", []);
+    return null;
+  }
+
+  return ethAmount.times(priceForCall.value).div(BIGINT_WAD);
+}

--- a/v1.template.yaml
+++ b/v1.template.yaml
@@ -125,6 +125,8 @@
           file: ./abis/v1/TerminalV1.json
         - name: TerminalDirectory
           file: ./abis/v1/TerminalDirectory.json
+        - name: Prices
+          file: ./abis/v1/Prices.json
       eventHandlers:
         - event: Pay(indexed uint256,indexed uint256,indexed address,uint256,string,address)
           handler: handlePay
@@ -175,6 +177,8 @@
           file: ./abis/v1/TerminalV1_1.json
         - name: TerminalDirectory
           file: ./abis/v1/TerminalDirectory.json
+        - name: Prices
+          file: ./abis/v1/Prices.json
       eventHandlers:
         - event: Pay(indexed uint256,indexed uint256,indexed address,uint256,uint256,uint256,string,address)
           handler: handlePay

--- a/v2.template.yaml
+++ b/v2.template.yaml
@@ -170,6 +170,8 @@
       abis:
         - name: JBETHPaymentTerminal
           file: ./abis/v2/JBETHPaymentTerminal.json
+        - name: JBPrices
+          file: ./abis/v2/JBPrices.json
       eventHandlers:
         - event: Pay(indexed uint256,indexed uint256,indexed uint256,address,address,uint256,uint256,string,bytes,address)
           handler: handlePay

--- a/v3.template.yaml
+++ b/v3.template.yaml
@@ -140,6 +140,8 @@
       abis:
         - name: JBETHPaymentTerminal
           file: ./abis/v3/JBETHPaymentTerminal.json
+        - name: JBPrices
+          file: ./abis/v3/JBPrices.json
       eventHandlers:
         - event: Pay(indexed uint256,indexed uint256,indexed uint256,address,address,uint256,uint256,string,bytes,address)
           handler: handlePay


### PR DESCRIPTION
Primary stuff:
- For all ETH amounts (payments, redemptions, etc) store the USD price of the ETH amount for that block, using the JB Prices contracts
- Store USD volume amounts on Projects + ProtocolLog entities, which are incremented at the time of a payment being received. This allows reading the total lifetime USD amount that has been contributed in ETH (vs. converting the total ETH amount to USD using the ETH price at a single block)

Secondary stuff:
- Add new properties to `Project` entity
  - `paymentsCount`: total number of payments received
  - `redeemCount`: total number of redemptions
  - `nftsMintedCount`: total number of ERC721 reward tokens minted
- Add `RedeemEvent.metadata`
- Add some missing logs